### PR TITLE
Run validation with multiple Terraform versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,16 +2,36 @@ name: Validate
 
 on: push
 
-env:
-  AWS_REGION: local
-
 jobs:
-  validate:
+  validate_terraform_versions:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        terraform_version:
+          - "0.15.5"
+          - "1.0.11"
+          - "1.1.9"
+          - "1.2.2"
+
+    defaults:
+      run:
+        working-directory: _test
+
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2.0.0
+      - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 0.15.5
+          terraform_version: ${{ matrix.terraform_version }}
       - run: terraform init
       - run: terraform validate
+
+  validate: # this is a workaround, see https://github.community/t/status-check-for-a-matrix-jobs/127354/6
+    if: ${{ always() }}
+    needs: [validate_terraform_versions]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check build status of all needed jobs
+        if: ${{ needs.validate_terraform_versions.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,6 @@ jobs:
       run:
         working-directory: _test
 
-    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/.terraform
-/.terraform.lock.hcl
+/_test/.terraform
+/_test/.terraform.lock.hcl

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region = "local"
+}
+
+module "vpc" {
+  source = "./.."
+
+  name       = "example"
+  cidr_block = "10.0.0.0/16"
+  size       = 2
+
+  vpc_endpoints = {
+    gateway   = ["dynamodb", "s3"]
+    interface = ["logs"]
+  }
+
+  tags = {
+    app = "example"
+    env = "production"
+  }  
+}


### PR DESCRIPTION
It's always the currently latest patch version for a minor version.