### PR TITLE
replace deprecated "vpc" attribute with "domain"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.2
+
+- [replace deprecated `vpc` attribute with `domain`](https://github.com/babbel/terraform-aws-vpc/pull/23)
+
 ## v1.2.1
 
 - [Provide empty map as default for `tags` variable](https://github.com/babbel/terraform-aws-vpc/pull/20)

--- a/availability-zone/main.tf
+++ b/availability-zone/main.tf
@@ -36,7 +36,7 @@ resource "aws_route_table_association" "public" {
 # NAT Gateway
 
 resource "aws_eip" "this" {
-  vpc = true
+  domain = "vpc"
 
   tags = merge({ Name = local.availability_zone }, var.tags)
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/pull/31567