### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,5 @@ module "vpc" {
     gateway   = ["dynamodb", "s3"]
     interface = ["logs"]
   }
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -14,7 +14,7 @@ module "vpc" {
     interface = ["logs"]
   }
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -17,5 +17,5 @@ module "vpc" {
   tags = {
     app = "example"
     env = "production"
-  }  
+  }
 }

--- a/availability-zone/main.tf
+++ b/availability-zone/main.tf
@@ -9,7 +9,7 @@ locals {
 resource "aws_route_table" "public" {
   vpc_id = var.vpc.id
 
-  tags = merge({ Name = "public - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "public - ${local.availability_zone}" }, var.default_tags, var.public_route_table_tags)
 }
 
 resource "aws_route" "internet_gateway" {
@@ -25,7 +25,7 @@ resource "aws_subnet" "public" {
   availability_zone       = local.availability_zone
   map_public_ip_on_launch = true
 
-  tags = merge({ Name = "public - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "public - ${local.availability_zone}" }, var.default_tags, var.public_subnet_tags)
 }
 
 resource "aws_route_table_association" "public" {
@@ -38,14 +38,14 @@ resource "aws_route_table_association" "public" {
 resource "aws_eip" "this" {
   domain = "vpc"
 
-  tags = merge({ Name = local.availability_zone }, var.tags)
+  tags = merge({ Name = local.availability_zone }, var.default_tags, var.nat_gateway_eip_tags)
 }
 
 resource "aws_nat_gateway" "this" {
   subnet_id     = aws_subnet.public.id
   allocation_id = aws_eip.this.id
 
-  tags = merge({ Name = local.availability_zone }, var.tags)
+  tags = merge({ Name = local.availability_zone }, var.default_tags, var.nat_gateway_tags)
 }
 
 # Private Subnet
@@ -53,7 +53,7 @@ resource "aws_nat_gateway" "this" {
 resource "aws_route_table" "private" {
   vpc_id = var.vpc.id
 
-  tags = merge({ Name = "private - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "private - ${local.availability_zone}" }, var.default_tags, var.private_route_table_tags)
 }
 
 resource "aws_route" "nat_gateway" {
@@ -69,7 +69,7 @@ resource "aws_subnet" "private" {
   availability_zone       = local.availability_zone
   map_public_ip_on_launch = false
 
-  tags = merge({ Name = "private - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "private - ${local.availability_zone}" }, var.default_tags, var.private_subnet_tags)
 }
 
 resource "aws_route_table_association" "private" {

--- a/availability-zone/variables.tf
+++ b/availability-zone/variables.tf
@@ -1,45 +1,106 @@
-variable "internet_gateway" {
-  description = "Internet Gateway which belongs to `var.vpc`"
+variable "default_tags" {
+  type    = map(string)
+  default = {}
 
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+variable "internet_gateway" {
   type = object({
     id = string
   })
+
+  description = <<EOS
+Internet Gateway which belongs to `var.vpc`
+EOS
+}
+
+variable "nat_gateway_eip_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the NAT Gateway EIP.
+EOS
+}
+
+variable "nat_gateway_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the NAT Gateway
+EOS
+}
+
+variable "private_route_table_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the private route table.
+EOS
+}
+
+variable "private_subnet_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the private subnet.
+EOS
+}
+
+variable "public_route_table_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the public route table.
+EOS
+}
+
+variable "public_subnet_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the public subnet.
+EOS
 }
 
 variable "subnet_bits" {
+  type = number
+
   description = <<EOS
-Number of bits to add to the VPC CIDR to get the size of the subnet CIDR
+Number of bits to add to the VPC CIDR to get the size of the subnet CIDR.
 
 This will be the `newbits` argument of [`cidrsubnet`](https://www.terraform.io/docs/language/functions/cidrsubnet.html).
 EOS
-
-  type = number
 }
 
 variable "subnet_index" {
+  type = number
+
   description = <<EOS
-The number of the subnet which will be used to calculate the subnet CIDR
+The number of the subnet which will be used to calculate the subnet CIDR.
 
 This will be used in the `netnum` argument of [`cidrsubnet`](https://www.terraform.io/docs/language/functions/cidrsubnet.html):
 
 * for the public subnet, it will be `2 * var.subnet_index`,
 * for the private subnet, it will be `2 * var.subnet_index + 1`.
 EOS
-
-  type = number
-}
-
-variable "tags" {
-  description = "Map of tags to assign to all resources supporting tags (in addition to the `Name` tag)"
-
-  type = map(string)
 }
 
 variable "vpc" {
-  description = "VPC in which the subnets and routing tables will be created"
-
   type = object({
     id         = string
     cidr_block = string
   })
+
+  description = <<EOS
+VPC in which the subnets and routing tables will be created.
+EOS
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_vpc" "this" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name }, var.default_tags, var.vpc_tags)
 }
 
 # Internet Gateway
@@ -17,7 +17,7 @@ resource "aws_vpc" "this" {
 resource "aws_internet_gateway" "this" {
   vpc_id = aws_vpc.this.id
 
-  tags = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name }, var.default_tags, var.internet_gateway_tags)
 }
 
 # Pairs of Public-Private Subnets per Availability Zone
@@ -32,7 +32,14 @@ module "availability_zone" {
   subnet_bits  = var.subnet_bits
   subnet_index = count.index
 
-  tags = var.tags
+  nat_gateway_eip_tags     = var.nat_gateway_eip_tags
+  nat_gateway_tags         = var.nat_gateway_tags
+  private_route_table_tags = var.private_route_table_tags
+  private_subnet_tags      = var.private_subnet_tags
+  public_route_table_tags  = var.public_route_table_tags
+  public_subnet_tags       = var.public_subnet_tags
+
+  default_tags = var.default_tags
 }
 
 # Subnet Groups (RDS, ElastiCache)
@@ -45,7 +52,7 @@ resource "aws_db_subnet_group" "this" {
 
   subnet_ids = module.availability_zone[*].private_subnet.id
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.db_subnet_group_tags)
 }
 
 resource "aws_elasticache_subnet_group" "this" {
@@ -69,7 +76,7 @@ resource "aws_vpc_endpoint" "gateway" {
 
   route_table_ids = module.availability_zone[*].private_route_table.id
 
-  tags = merge({ Name = each.key }, var.tags)
+  tags = merge({ Name = each.key }, var.default_tags, var.gateway_vpc_endpoint_tags)
 }
 
 # VPC Endpoints: type `Interface`
@@ -86,7 +93,7 @@ resource "aws_vpc_endpoint" "interface" {
   subnet_ids         = module.availability_zone[*].private_subnet.id
   security_group_ids = [aws_security_group.vpc-endpoints-interface[0].id]
 
-  tags = merge({ Name = each.key }, var.tags)
+  tags = merge({ Name = each.key }, var.default_tags, var.interface_vpc_endpoint_tags)
 
   depends_on = [
     aws_security_group_rule.vpc-endpoints-interface-ingress,
@@ -102,7 +109,7 @@ resource "aws_security_group" "vpc-endpoints-interface" {
   name        = "vpc-endpoints-interface"
   description = "VPC Endpoints Interface"
 
-  tags = merge({ Name = "VPC Endpoints Interface" }, var.tags)
+  tags = merge({ Name = "VPC Endpoints Interface" }, var.default_tags, var.interface_vpc_endpoint_security_group_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
 output "db_subnet_group" {
   description = "DB subnet group containing all private subnets"
-  value = var.create_db_subnet_group ? aws_db_subnet_group.this[0] : null
+  value       = var.create_db_subnet_group ? aws_db_subnet_group.this[0] : null
 }
 
 output "elasticache_subnet_group" {
   description = "ElastiCache subnet group containing all private subnets"
-  value = var.create_elasticache_subnet_group ? aws_elasticache_subnet_group.this[0] : null
+  value       = var.create_elasticache_subnet_group ? aws_elasticache_subnet_group.this[0] : null
 }
 
 output "private_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,62 +1,166 @@
 variable "cidr_block" {
-  description = "VPC CIDR"
-
   type = string
+
+  description = <<EOS
+VPC CIDR.
+EOS
 }
 
 variable "create_db_subnet_group" {
-  description = "Whether to create a DB subnet group"
-
   type    = bool
   default = false
+
+  description = <<EOS
+Whether to create a DB subnet group.
+EOS
 }
 
 variable "create_elasticache_subnet_group" {
-  description = "Whether to create an ElastiCache subnet group"
-
   type    = bool
   default = false
+
+  description = <<EOS
+Whether to create an ElastiCache subnet group.
+EOS
+}
+
+variable "db_subnet_group_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the DB subnet group.
+EOS
+}
+
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+variable "gateway_vpc_endpoint_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the VPC Endpoints of type `Gateway`.
+EOS
+}
+
+variable "interface_vpc_endpoint_security_group_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the security groups for the VPC Endpoint of type `Interface`.
+EOS
+}
+
+variable "interface_vpc_endpoint_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the VPC Endpoints of type `Interface`.
+EOS
+}
+
+variable "internet_gateway_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the Internet Gateway.
+EOS
 }
 
 variable "name" {
-  description = "Name to be used in all `Name` tags shown in the AWS Console"
-
   type = string
+
+  description = <<EOS
+Name to be used in all `Name` tags shown in the AWS Console.
+EOS
+}
+
+variable "nat_gateway_eip_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the NAT Gateway EIPs.
+EOS
+}
+
+variable "nat_gateway_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the NAT Gateways.
+EOS
+}
+
+variable "private_route_table_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the private route tables.
+EOS
+}
+
+variable "private_subnet_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the private subnets.
+EOS
+}
+
+variable "public_route_table_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the public route tables.
+EOS
+}
+
+variable "public_subnet_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the public subnets.
+EOS
 }
 
 variable "size" {
+  type = number
+
   description = <<EOS
-Number of availability zones to cover
+Number of availability zones to cover.
 
 This will be also the number public-private subnet pairs to create.
 If subnet groups for RDS and/or ElastiCache shall be created, the number must be at least 2.
 EOS
-
-  type = number
 }
 
 variable "subnet_bits" {
-  description = "Number of bits to add to the VPC CIDR to get the size of the subnet CIDR"
-
   type    = number
   default = 4
-}
 
-variable "tags" {
-  description = "Map of tags to assign to all resources supporting tags (in addition to the `Name` tag)"
-
-  type    = map(string)
-  default = {}
+  description = <<EOS
+Number of bits to add to the VPC CIDR to get the size of the subnet CIDR.
+EOS
 }
 
 variable "vpc_endpoints" {
-  description = <<EOS
-Service name identifiers for the VPC endpoints.
-
-Every VPC endpoint belongs to a service name like `com.amazonaws.REGION.IDENTIFIER`.
-The lists of this variable (grouped by VPC endpoint type) are expecting just the `IDENTIFIER` of the service name.
-EOS
-
   type = object({
     gateway   = list(string)
     interface = list(string)
@@ -65,4 +169,20 @@ EOS
     gateway   = []
     interface = []
   }
+
+  description = <<EOS
+Service name identifiers for the VPC endpoints.
+
+Every VPC endpoint belongs to a service name like `com.amazonaws.REGION.IDENTIFIER`.
+The lists of this variable (grouped by VPC endpoint type) are expecting just the `IDENTIFIER` of the service name.
+EOS
+}
+
+variable "vpc_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the VPC.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.