### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,5 @@ module "vpc" {
     gateway   = ["dynamodb", "s3"]
     interface = ["logs"]
   }
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -14,7 +14,7 @@ module "vpc" {
     interface = ["logs"]
   }
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/availability-zone/main.tf
+++ b/availability-zone/main.tf
@@ -9,7 +9,7 @@ locals {
 resource "aws_route_table" "public" {
   vpc_id = var.vpc.id
 
-  tags = merge({ Name = "public - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "public - ${local.availability_zone}" }, var.default_tags)
 }
 
 resource "aws_route" "internet_gateway" {
@@ -25,7 +25,7 @@ resource "aws_subnet" "public" {
   availability_zone       = local.availability_zone
   map_public_ip_on_launch = true
 
-  tags = merge({ Name = "public - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "public - ${local.availability_zone}" }, var.default_tags)
 }
 
 resource "aws_route_table_association" "public" {
@@ -38,14 +38,14 @@ resource "aws_route_table_association" "public" {
 resource "aws_eip" "this" {
   domain = "vpc"
 
-  tags = merge({ Name = local.availability_zone }, var.tags)
+  tags = merge({ Name = local.availability_zone }, var.default_tags)
 }
 
 resource "aws_nat_gateway" "this" {
   subnet_id     = aws_subnet.public.id
   allocation_id = aws_eip.this.id
 
-  tags = merge({ Name = local.availability_zone }, var.tags)
+  tags = merge({ Name = local.availability_zone }, var.default_tags)
 }
 
 # Private Subnet
@@ -53,7 +53,7 @@ resource "aws_nat_gateway" "this" {
 resource "aws_route_table" "private" {
   vpc_id = var.vpc.id
 
-  tags = merge({ Name = "private - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "private - ${local.availability_zone}" }, var.default_tags)
 }
 
 resource "aws_route" "nat_gateway" {
@@ -69,7 +69,7 @@ resource "aws_subnet" "private" {
   availability_zone       = local.availability_zone
   map_public_ip_on_launch = false
 
-  tags = merge({ Name = "private - ${local.availability_zone}" }, var.tags)
+  tags = merge({ Name = "private - ${local.availability_zone}" }, var.default_tags)
 }
 
 resource "aws_route_table_association" "private" {

--- a/availability-zone/variables.tf
+++ b/availability-zone/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "internet_gateway" {
   type = object({
     id = string
@@ -28,15 +37,6 @@ This will be used in the `netnum` argument of [`cidrsubnet`](https://www.terrafo
 
 * for the public subnet, it will be `2 * var.subnet_index`,
 * for the private subnet, it will be `2 * var.subnet_index + 1`.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_vpc" "this" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name }, var.default_tags)
 }
 
 # Internet Gateway
@@ -17,7 +17,7 @@ resource "aws_vpc" "this" {
 resource "aws_internet_gateway" "this" {
   vpc_id = aws_vpc.this.id
 
-  tags = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name }, var.default_tags)
 }
 
 # Pairs of Public-Private Subnets per Availability Zone
@@ -32,7 +32,7 @@ module "availability_zone" {
   subnet_bits  = var.subnet_bits
   subnet_index = count.index
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 # Subnet Groups (RDS, ElastiCache)
@@ -45,7 +45,7 @@ resource "aws_db_subnet_group" "this" {
 
   subnet_ids = module.availability_zone[*].private_subnet.id
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_elasticache_subnet_group" "this" {
@@ -69,7 +69,7 @@ resource "aws_vpc_endpoint" "gateway" {
 
   route_table_ids = module.availability_zone[*].private_route_table.id
 
-  tags = merge({ Name = each.key }, var.tags)
+  tags = merge({ Name = each.key }, var.default_tags)
 }
 
 # VPC Endpoints: type `Interface`
@@ -86,7 +86,7 @@ resource "aws_vpc_endpoint" "interface" {
   subnet_ids         = module.availability_zone[*].private_subnet.id
   security_group_ids = [aws_security_group.vpc-endpoints-interface[0].id]
 
-  tags = merge({ Name = each.key }, var.tags)
+  tags = merge({ Name = each.key }, var.default_tags)
 
   depends_on = [
     aws_security_group_rule.vpc-endpoints-interface-ingress,
@@ -102,7 +102,7 @@ resource "aws_security_group" "vpc-endpoints-interface" {
   name        = "vpc-endpoints-interface"
   description = "VPC Endpoints Interface"
 
-  tags = merge({ Name = "VPC Endpoints Interface" }, var.tags)
+  tags = merge({ Name = "VPC Endpoints Interface" }, var.default_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ module "availability_zone" {
   subnet_bits  = var.subnet_bits
   subnet_index = count.index
 
-  tags = var.default_tags
+  default_tags = var.default_tags
 }
 
 # Subnet Groups (RDS, ElastiCache)

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,15 @@ Whether to create an ElastiCache subnet group.
 EOS
 }
 
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "name" {
   type = string
 
@@ -49,15 +58,6 @@ variable "subnet_bits" {
 
   description = <<EOS
 Number of bits to add to the VPC CIDR to get the size of the subnet CIDR.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.